### PR TITLE
Revert "Remove epoch2 started code (#3038)"

### DIFF
--- a/nano/core_test/block.cpp
+++ b/nano/core_test/block.cpp
@@ -277,7 +277,7 @@ TEST (frontier_req, serialization)
 	std::vector<uint8_t> bytes;
 	{
 		nano::vectorstream stream (bytes);
-		request1.serialize (stream);
+		request1.serialize (stream, false);
 	}
 	auto error (false);
 	nano::bufferstream stream (bytes.data (), bytes.size ());
@@ -297,7 +297,7 @@ TEST (block, publish_req_serialization)
 	std::vector<uint8_t> bytes;
 	{
 		nano::vectorstream stream (bytes);
-		req.serialize (stream);
+		req.serialize (stream, false);
 	}
 	auto error (false);
 	nano::bufferstream stream2 (bytes.data (), bytes.size ());

--- a/nano/core_test/block_store.cpp
+++ b/nano/core_test/block_store.cpp
@@ -2023,6 +2023,7 @@ TEST (block_store, rocksdb_force_test_env_variable)
 	// Set environment variable
 	constexpr auto env_var = "TEST_USE_ROCKSDB";
 	auto value = std::getenv (env_var);
+	(void)value;
 
 	auto store = nano::make_store (logger, nano::unique_path ());
 

--- a/nano/core_test/ledger.cpp
+++ b/nano/core_test/ledger.cpp
@@ -3171,6 +3171,57 @@ TEST (ledger, work_validation)
 	process_block (epoch, nano::block_details (nano::epoch::epoch_1, false, false, true));
 }
 
+TEST (ledger, epoch_2_started_flag)
+{
+	nano::system system (2);
+
+	auto & node1 = *system.nodes[0];
+	ASSERT_FALSE (node1.ledger.cache.epoch_2_started.load ());
+	ASSERT_NE (nullptr, system.upgrade_genesis_epoch (node1, nano::epoch::epoch_1));
+	ASSERT_FALSE (node1.ledger.cache.epoch_2_started.load ());
+	ASSERT_NE (nullptr, system.upgrade_genesis_epoch (node1, nano::epoch::epoch_2));
+	ASSERT_TRUE (node1.ledger.cache.epoch_2_started.load ());
+
+	auto & node2 = *system.nodes[1];
+	nano::keypair key;
+	auto epoch1 = system.upgrade_genesis_epoch (node2, nano::epoch::epoch_1);
+	ASSERT_NE (nullptr, epoch1);
+	ASSERT_FALSE (node2.ledger.cache.epoch_2_started.load ());
+	nano::state_block send (nano::dev_genesis_key.pub, epoch1->hash (), nano::dev_genesis_key.pub, nano::genesis_amount - 1, key.pub, nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *system.work.generate (epoch1->hash ()));
+	ASSERT_EQ (nano::process_result::progress, node2.process (send).code);
+	ASSERT_FALSE (node2.ledger.cache.epoch_2_started.load ());
+	nano::state_block epoch2 (key.pub, 0, 0, 0, node2.ledger.epoch_link (nano::epoch::epoch_2), nano::dev_genesis_key.prv, nano::dev_genesis_key.pub, *system.work.generate (key.pub));
+	ASSERT_EQ (nano::process_result::progress, node2.process (epoch2).code);
+	ASSERT_TRUE (node2.ledger.cache.epoch_2_started.load ());
+
+	// Ensure state is kept on ledger initialization
+	nano::stat stats;
+	nano::ledger ledger (node1.store, stats);
+	ASSERT_TRUE (ledger.cache.epoch_2_started.load ());
+}
+
+TEST (ledger, epoch_2_upgrade_callback)
+{
+	nano::genesis genesis;
+	nano::stat stats;
+	nano::logger_mt logger;
+	auto store = nano::make_store (logger, nano::unique_path ());
+	ASSERT_TRUE (!store->init_error ());
+	bool cb_hit = false;
+	nano::ledger ledger (*store, stats, nano::generate_cache (), [&cb_hit]() {
+		cb_hit = true;
+	});
+	{
+		auto transaction (store->tx_begin_write ());
+		store->initialize (transaction, genesis, ledger.cache);
+	}
+	nano::work_pool pool (std::numeric_limits<unsigned>::max ());
+	upgrade_epoch (pool, ledger, nano::epoch::epoch_1);
+	ASSERT_FALSE (cb_hit);
+	auto latest = upgrade_epoch (pool, ledger, nano::epoch::epoch_2);
+	ASSERT_TRUE (cb_hit);
+}
+
 TEST (ledger, dependents_confirmed)
 {
 	nano::block_builder builder;

--- a/nano/core_test/message.cpp
+++ b/nano/core_test/message.cpp
@@ -12,7 +12,7 @@ TEST (message, keepalive_serialization)
 	std::vector<uint8_t> bytes;
 	{
 		nano::vectorstream stream (bytes);
-		request1.serialize (stream);
+		request1.serialize (stream, false);
 	}
 	auto error (false);
 	nano::bufferstream stream (bytes.data (), bytes.size ());
@@ -30,7 +30,7 @@ TEST (message, keepalive_deserialize)
 	std::vector<uint8_t> bytes;
 	{
 		nano::vectorstream stream (bytes);
-		message1.serialize (stream);
+		message1.serialize (stream, false);
 	}
 	nano::bufferstream stream (bytes.data (), bytes.size ());
 	auto error (false);
@@ -50,14 +50,14 @@ TEST (message, publish_serialization)
 	std::vector<uint8_t> bytes;
 	{
 		nano::vectorstream stream (bytes);
-		publish.header.serialize (stream);
+		publish.header.serialize (stream, false);
 	}
 	ASSERT_EQ (8, bytes.size ());
 	ASSERT_EQ (0x52, bytes[0]);
 	ASSERT_EQ (0x41, bytes[1]);
 	ASSERT_EQ (params.protocol.protocol_version, bytes[2]);
 	ASSERT_EQ (params.protocol.protocol_version, bytes[3]);
-	ASSERT_EQ (params.protocol.protocol_version_min (), bytes[4]);
+	ASSERT_EQ (params.protocol.protocol_version_min (false), bytes[4]);
 	ASSERT_EQ (static_cast<uint8_t> (nano::message_type::publish), bytes[5]);
 	ASSERT_EQ (0x00, bytes[6]); // extensions
 	ASSERT_EQ (static_cast<uint8_t> (nano::block_type::send), bytes[7]);
@@ -65,7 +65,7 @@ TEST (message, publish_serialization)
 	auto error (false);
 	nano::message_header header (error, stream);
 	ASSERT_FALSE (error);
-	ASSERT_EQ (params.protocol.protocol_version_min (), header.version_min ());
+	ASSERT_EQ (params.protocol.protocol_version_min (false), header.version_min ());
 	ASSERT_EQ (params.protocol.protocol_version, header.version_using);
 	ASSERT_EQ (params.protocol.protocol_version, header.version_max);
 	ASSERT_EQ (nano::message_type::publish, header.type);
@@ -79,7 +79,7 @@ TEST (message, confirm_ack_serialization)
 	std::vector<uint8_t> bytes;
 	{
 		nano::vectorstream stream1 (bytes);
-		con1.serialize (stream1);
+		con1.serialize (stream1, false);
 	}
 	nano::bufferstream stream2 (bytes.data (), bytes.size ());
 	bool error (false);
@@ -107,7 +107,7 @@ TEST (message, confirm_ack_hash_serialization)
 	std::vector<uint8_t> bytes;
 	{
 		nano::vectorstream stream1 (bytes);
-		con1.serialize (stream1);
+		con1.serialize (stream1, false);
 	}
 	nano::bufferstream stream2 (bytes.data (), bytes.size ());
 	bool error (false);
@@ -135,7 +135,7 @@ TEST (message, confirm_req_serialization)
 	std::vector<uint8_t> bytes;
 	{
 		nano::vectorstream stream (bytes);
-		req.serialize (stream);
+		req.serialize (stream, false);
 	}
 	auto error (false);
 	nano::bufferstream stream2 (bytes.data (), bytes.size ());
@@ -155,7 +155,7 @@ TEST (message, confirm_req_hash_serialization)
 	std::vector<uint8_t> bytes;
 	{
 		nano::vectorstream stream (bytes);
-		req.serialize (stream);
+		req.serialize (stream, false);
 	}
 	auto error (false);
 	nano::bufferstream stream2 (bytes.data (), bytes.size ());
@@ -188,7 +188,7 @@ TEST (message, confirm_req_hash_batch_serialization)
 	std::vector<uint8_t> bytes;
 	{
 		nano::vectorstream stream (bytes);
-		req.serialize (stream);
+		req.serialize (stream, false);
 	}
 	auto error (false);
 	nano::bufferstream stream2 (bytes.data (), bytes.size ());

--- a/nano/core_test/message_parser.cpp
+++ b/nano/core_test/message_parser.cpp
@@ -67,14 +67,14 @@ TEST (message_parser, exact_confirm_ack_size)
 	nano::network_filter filter (1);
 	nano::block_uniquer block_uniquer;
 	nano::vote_uniquer vote_uniquer (block_uniquer);
-	nano::message_parser parser (filter, block_uniquer, vote_uniquer, visitor, system.work);
+	nano::message_parser parser (filter, block_uniquer, vote_uniquer, visitor, system.work, false);
 	auto block (std::make_shared<nano::send_block> (1, 1, 2, nano::keypair ().prv, 4, *system.work.generate (nano::root (1))));
 	auto vote (std::make_shared<nano::vote> (0, nano::keypair ().prv, 0, std::move (block)));
 	nano::confirm_ack message (vote);
 	std::vector<uint8_t> bytes;
 	{
 		nano::vectorstream stream (bytes);
-		message.serialize (stream);
+		message.serialize (stream, true);
 	}
 	ASSERT_EQ (0, visitor.confirm_ack_count);
 	ASSERT_EQ (parser.status, nano::message_parser::parse_status::success);
@@ -101,13 +101,13 @@ TEST (message_parser, exact_confirm_req_size)
 	nano::network_filter filter (1);
 	nano::block_uniquer block_uniquer;
 	nano::vote_uniquer vote_uniquer (block_uniquer);
-	nano::message_parser parser (filter, block_uniquer, vote_uniquer, visitor, system.work);
+	nano::message_parser parser (filter, block_uniquer, vote_uniquer, visitor, system.work, false);
 	auto block (std::make_shared<nano::send_block> (1, 1, 2, nano::keypair ().prv, 4, *system.work.generate (nano::root (1))));
 	nano::confirm_req message (std::move (block));
 	std::vector<uint8_t> bytes;
 	{
 		nano::vectorstream stream (bytes);
-		message.serialize (stream);
+		message.serialize (stream, false);
 	}
 	ASSERT_EQ (0, visitor.confirm_req_count);
 	ASSERT_EQ (parser.status, nano::message_parser::parse_status::success);
@@ -134,13 +134,13 @@ TEST (message_parser, exact_confirm_req_hash_size)
 	nano::network_filter filter (1);
 	nano::block_uniquer block_uniquer;
 	nano::vote_uniquer vote_uniquer (block_uniquer);
-	nano::message_parser parser (filter, block_uniquer, vote_uniquer, visitor, system.work);
+	nano::message_parser parser (filter, block_uniquer, vote_uniquer, visitor, system.work, true);
 	nano::send_block block (1, 1, 2, nano::keypair ().prv, 4, *system.work.generate (nano::root (1)));
 	nano::confirm_req message (block.hash (), block.root ());
 	std::vector<uint8_t> bytes;
 	{
 		nano::vectorstream stream (bytes);
-		message.serialize (stream);
+		message.serialize (stream, false);
 	}
 	ASSERT_EQ (0, visitor.confirm_req_count);
 	ASSERT_EQ (parser.status, nano::message_parser::parse_status::success);
@@ -167,13 +167,13 @@ TEST (message_parser, exact_publish_size)
 	nano::network_filter filter (1);
 	nano::block_uniquer block_uniquer;
 	nano::vote_uniquer vote_uniquer (block_uniquer);
-	nano::message_parser parser (filter, block_uniquer, vote_uniquer, visitor, system.work);
+	nano::message_parser parser (filter, block_uniquer, vote_uniquer, visitor, system.work, true);
 	auto block (std::make_shared<nano::send_block> (1, 1, 2, nano::keypair ().prv, 4, *system.work.generate (nano::root (1))));
 	nano::publish message (std::move (block));
 	std::vector<uint8_t> bytes;
 	{
 		nano::vectorstream stream (bytes);
-		message.serialize (stream);
+		message.serialize (stream, false);
 	}
 	ASSERT_EQ (0, visitor.publish_count);
 	ASSERT_EQ (parser.status, nano::message_parser::parse_status::success);
@@ -200,12 +200,12 @@ TEST (message_parser, exact_keepalive_size)
 	nano::network_filter filter (1);
 	nano::block_uniquer block_uniquer;
 	nano::vote_uniquer vote_uniquer (block_uniquer);
-	nano::message_parser parser (filter, block_uniquer, vote_uniquer, visitor, system.work);
+	nano::message_parser parser (filter, block_uniquer, vote_uniquer, visitor, system.work, true);
 	nano::keepalive message;
 	std::vector<uint8_t> bytes;
 	{
 		nano::vectorstream stream (bytes);
-		message.serialize (stream);
+		message.serialize (stream, true);
 	}
 	ASSERT_EQ (0, visitor.keepalive_count);
 	ASSERT_EQ (parser.status, nano::message_parser::parse_status::success);

--- a/nano/core_test/network.cpp
+++ b/nano/core_test/network.cpp
@@ -765,7 +765,7 @@ TEST (tcp_listener, tcp_node_id_handshake)
 	auto bootstrap_endpoint (system.nodes[0]->bootstrap.endpoint ());
 	auto cookie (system.nodes[0]->network.syn_cookies.assign (nano::transport::map_tcp_to_endpoint (bootstrap_endpoint)));
 	nano::node_id_handshake node_id_handshake (cookie, boost::none);
-	auto input (node_id_handshake.to_shared_const_buffer ());
+	auto input (node_id_handshake.to_shared_const_buffer (false));
 	std::atomic<bool> write_done (false);
 	socket->async_connect (bootstrap_endpoint, [&input, socket, &write_done] (boost::system::error_code const & ec) {
 		ASSERT_FALSE (ec);
@@ -780,7 +780,7 @@ TEST (tcp_listener, tcp_node_id_handshake)
 
 	boost::optional<std::pair<nano::account, nano::signature>> response_zero (std::make_pair (nano::account (0), nano::signature (0)));
 	nano::node_id_handshake node_id_handshake_response (boost::none, response_zero);
-	auto output (node_id_handshake_response.to_bytes ());
+	auto output (node_id_handshake_response.to_bytes (false));
 	std::atomic<bool> done (false);
 	socket->async_read (output, output->size (), [&output, &done] (boost::system::error_code const & ec, size_t size_a) {
 		ASSERT_FALSE (ec);
@@ -820,7 +820,7 @@ TEST (tcp_listener, tcp_listener_timeout_node_id_handshake)
 	auto socket (std::make_shared<nano::socket> (*node0));
 	auto cookie (node0->network.syn_cookies.assign (nano::transport::map_tcp_to_endpoint (node0->bootstrap.endpoint ())));
 	nano::node_id_handshake node_id_handshake (cookie, boost::none);
-	auto input (node_id_handshake.to_shared_const_buffer ());
+	auto input (node_id_handshake.to_shared_const_buffer (false));
 	socket->async_connect (node0->bootstrap.endpoint (), [&input, socket] (boost::system::error_code const & ec) {
 		ASSERT_FALSE (ec);
 		socket->async_write (input, [&input] (boost::system::error_code const & ec, size_t size_a) {
@@ -979,7 +979,7 @@ TEST (network, bandwidth_limiter)
 	nano::system system;
 	nano::genesis genesis;
 	nano::publish message (genesis.open);
-	auto message_size = message.to_bytes ()->size ();
+	auto message_size = message.to_bytes (false)->size ();
 	auto message_limit = 4; // must be multiple of the number of channels
 	nano::node_config node_config (nano::get_available_port (), system.logging);
 	node_config.bandwidth_limit = message_limit * message_size;

--- a/nano/core_test/network_filter.cpp
+++ b/nano/core_test/network_filter.cpp
@@ -12,7 +12,7 @@ TEST (network_filter, unit)
 	nano::network_filter filter (1);
 	auto one_block = [&filter] (std::shared_ptr<nano::block> const & block_a, bool expect_duplicate_a) {
 		nano::publish message (block_a);
-		auto bytes (message.to_bytes ());
+		auto bytes (message.to_bytes (false));
 		nano::bufferstream stream (bytes->data (), bytes->size ());
 
 		// First read the header
@@ -79,7 +79,7 @@ TEST (network_filter, many)
 					 .build_shared ();
 
 		nano::publish message (block);
-		auto bytes (message.to_bytes ());
+		auto bytes (message.to_bytes (false));
 		nano::bufferstream stream (bytes->data (), bytes->size ());
 
 		// First read the header

--- a/nano/core_test/node.cpp
+++ b/nano/core_test/node.cpp
@@ -1546,7 +1546,7 @@ TEST (node, fork_no_vote_quorum)
 	std::vector<uint8_t> buffer;
 	{
 		nano::vectorstream stream (buffer);
-		confirm.serialize (stream);
+		confirm.serialize (stream, false);
 	}
 	auto channel = node2.network.find_node_id (node3.node_id.pub);
 	ASSERT_NE (nullptr, channel);
@@ -3956,6 +3956,57 @@ TEST (node, aggressive_flooding)
 	ASSERT_EQ (1 + 2 * nodes_wallets.size () + 2, node1.ledger.cache.block_count);
 }
 
+TEST (node, max_work_generate_difficulty)
+{
+	nano::system system;
+	nano::node_config node_config (nano::get_available_port (), system.logging);
+	node_config.max_work_generate_multiplier = 2.0;
+	auto & node = *system.add_node (node_config);
+	auto initial_difficulty = node.default_difficulty (nano::work_version::work_1);
+	ASSERT_EQ (node.max_work_generate_difficulty (nano::work_version::work_1), nano::difficulty::from_multiplier (node.config.max_work_generate_multiplier, initial_difficulty));
+	ASSERT_NE (nullptr, system.upgrade_genesis_epoch (node, nano::epoch::epoch_1));
+	ASSERT_NE (nullptr, system.upgrade_genesis_epoch (node, nano::epoch::epoch_2));
+	auto final_difficulty = node.default_difficulty (nano::work_version::work_1);
+	ASSERT_NE (final_difficulty, initial_difficulty);
+	ASSERT_EQ (node.max_work_generate_difficulty (nano::work_version::work_1), nano::difficulty::from_multiplier (node.config.max_work_generate_multiplier, final_difficulty));
+}
+
+TEST (active_difficulty, recalculate_work)
+{
+	nano::system system;
+	nano::node_config node_config (nano::get_available_port (), system.logging);
+	node_config.enable_voting = false;
+	auto & node1 = *system.add_node (node_config);
+	nano::genesis genesis;
+	nano::keypair key1;
+	ASSERT_EQ (node1.network_params.network.publish_thresholds.epoch_2, node1.active.active_difficulty ());
+	auto send1 = nano::send_block_builder ()
+	             .previous (genesis.hash ())
+	             .destination (key1.pub)
+	             .balance (0)
+	             .sign (nano::dev_genesis_key.prv, nano::dev_genesis_key.pub)
+	             .work (*system.work.generate (genesis.hash ()))
+	             .build_shared ();
+	auto multiplier1 = nano::difficulty::to_multiplier (send1->difficulty (), node1.network_params.network.publish_thresholds.epoch_2);
+	// Process as local block
+	node1.process_active (send1);
+	ASSERT_TIMELY (2s, !node1.active.empty ());
+	auto sum (std::accumulate (node1.active.multipliers_cb.begin (), node1.active.multipliers_cb.end (), double(0)));
+	ASSERT_EQ (node1.active.active_difficulty (), nano::difficulty::from_multiplier (sum / node1.active.multipliers_cb.size (), node1.network_params.network.publish_thresholds.epoch_2));
+	nano::unique_lock<std::mutex> lock (node1.active.mutex);
+	// Fake history records to force work recalculation
+	for (auto i (0); i < node1.active.multipliers_cb.size (); i++)
+	{
+		node1.active.multipliers_cb.push_back (multiplier1 * (1 + i / 100.));
+	}
+	node1.work_generate_blocking (*send1);
+	node1.process_active (send1);
+	node1.active.update_active_multiplier (lock);
+	sum = std::accumulate (node1.active.multipliers_cb.begin (), node1.active.multipliers_cb.end (), double(0));
+	ASSERT_EQ (node1.active.trended_active_multiplier.load (), sum / node1.active.multipliers_cb.size ());
+	lock.unlock ();
+}
+
 TEST (node, node_sequence)
 {
 	nano::system system (3);
@@ -4659,6 +4710,21 @@ TEST (node, deferred_dependent_elections)
 	node.block_processor.flush ();
 	ASSERT_TRUE (node.active.active (receive->qualified_root ()));
 }
+}
+
+TEST (node, default_difficulty)
+{
+	nano::system system (1);
+	auto & node (*system.nodes[0]);
+	auto const & thresholds = nano::network_params{}.network.publish_thresholds;
+	ASSERT_EQ (thresholds.epoch_1, node.default_difficulty (nano::work_version::work_1));
+	ASSERT_EQ (thresholds.epoch_1, node.default_receive_difficulty (nano::work_version::work_1));
+	nano::upgrade_epoch (system.work, node.ledger, nano::epoch::epoch_1);
+	ASSERT_EQ (thresholds.epoch_1, node.default_difficulty (nano::work_version::work_1));
+	ASSERT_EQ (thresholds.epoch_1, node.default_receive_difficulty (nano::work_version::work_1));
+	nano::upgrade_epoch (system.work, node.ledger, nano::epoch::epoch_2);
+	ASSERT_EQ (thresholds.epoch_2, node.default_difficulty (nano::work_version::work_1));
+	ASSERT_EQ (thresholds.epoch_2_receive, node.default_receive_difficulty (nano::work_version::work_1));
 }
 
 TEST (rep_crawler, recently_confirmed)

--- a/nano/core_test/peer_container.cpp
+++ b/nano/core_test/peer_container.cpp
@@ -181,7 +181,7 @@ TEST (peer_container, depeer)
 	nano::endpoint endpoint0 (boost::asio::ip::address_v6::loopback (), nano::get_available_port ());
 	nano::keepalive message;
 	message.header.version_using = 1;
-	auto bytes (message.to_bytes ());
+	auto bytes (message.to_bytes (false));
 	nano::message_buffer buffer = { bytes->data (), bytes->size (), endpoint0 };
 	system.nodes[0]->network.udp_channels.receive_action (&buffer);
 	ASSERT_EQ (1, system.nodes[0]->stats.count (nano::stat::type::udp, nano::stat::detail::outdated_version));

--- a/nano/core_test/websocket.cpp
+++ b/nano/core_test/websocket.cpp
@@ -48,6 +48,79 @@ TEST (websocket, subscription_edge)
 	ASSERT_TIMELY (5s, future.wait_for (0s) == std::future_status::ready);
 }
 
+// Test client subscribing to changes in active_multiplier
+TEST (websocket, active_difficulty)
+{
+	nano::system system;
+	nano::node_config config (nano::get_available_port (), system.logging);
+	config.websocket_config.enabled = true;
+	config.websocket_config.port = nano::get_available_port ();
+	nano::node_flags node_flags;
+	// Disable auto-updating active difficulty (multiplier) to prevent intermittent failures
+	node_flags.disable_request_loop = true;
+	auto node1 (system.add_node (config, node_flags));
+
+	// "Start" epoch 2
+	node1->ledger.cache.epoch_2_started = true;
+	ASSERT_EQ (node1->default_difficulty (nano::work_version::work_1), node1->network_params.network.publish_thresholds.epoch_2);
+
+	ASSERT_EQ (0, node1->websocket_server->subscriber_count (nano::websocket::topic::active_difficulty));
+
+	std::atomic<bool> ack_ready{ false };
+	auto task = ([&ack_ready, config, &node1]() {
+		fake_websocket_client client (config.websocket_config.port);
+		client.send_message (R"json({"action": "subscribe", "topic": "active_difficulty", "ack": true})json");
+		client.await_ack ();
+		ack_ready = true;
+		EXPECT_EQ (1, node1->websocket_server->subscriber_count (nano::websocket::topic::active_difficulty));
+		return client.get_response ();
+	});
+	auto future = std::async (std::launch::async, task);
+
+	ASSERT_TIMELY (5s, ack_ready);
+
+	// Fake history records and force a trended_active_multiplier change
+	{
+		nano::unique_lock<std::mutex> lock (node1->active.mutex);
+		node1->active.multipliers_cb.push_front (10.);
+		node1->active.update_active_multiplier (lock);
+	}
+
+	ASSERT_TIMELY (5s, future.wait_for (0s) == std::future_status::ready);
+
+	// Check active_difficulty response
+	boost::optional<std::string> response = future.get ();
+	ASSERT_TRUE (response);
+	std::stringstream stream;
+	stream << response;
+	boost::property_tree::ptree event;
+	boost::property_tree::read_json (stream, event);
+	ASSERT_EQ (event.get<std::string> ("topic"), "active_difficulty");
+
+	auto message_contents = event.get_child ("message");
+	uint64_t network_minimum;
+	nano::from_string_hex (message_contents.get<std::string> ("network_minimum"), network_minimum);
+	ASSERT_EQ (network_minimum, node1->default_difficulty (nano::work_version::work_1));
+
+	uint64_t network_receive_minimum;
+	nano::from_string_hex (message_contents.get<std::string> ("network_receive_minimum"), network_receive_minimum);
+	ASSERT_EQ (network_receive_minimum, node1->default_receive_difficulty (nano::work_version::work_1));
+
+	uint64_t network_current;
+	nano::from_string_hex (message_contents.get<std::string> ("network_current"), network_current);
+	ASSERT_EQ (network_current, node1->active.active_difficulty ());
+
+	double multiplier = message_contents.get<double> ("multiplier");
+	ASSERT_NEAR (multiplier, nano::difficulty::to_multiplier (node1->active.active_difficulty (), node1->default_difficulty (nano::work_version::work_1)), 1e-6);
+
+	uint64_t network_receive_current;
+	nano::from_string_hex (message_contents.get<std::string> ("network_receive_current"), network_receive_current);
+	auto network_receive_current_multiplier (nano::difficulty::to_multiplier (network_receive_current, network_receive_minimum));
+	auto network_receive_current_normalized_multiplier (nano::normalized_multiplier (network_receive_current_multiplier, network_receive_minimum));
+	ASSERT_NEAR (network_receive_current_normalized_multiplier, multiplier, 1e-6);
+}
+
+>>>>>>> parent of 9690113b (Remove epoch2 started code (#3038))
 // Subscribes to block confirmations, confirms a block and then awaits websocket notification
 TEST (websocket, confirmation)
 {

--- a/nano/node/bootstrap/bootstrap_server.cpp
+++ b/nano/node/bootstrap/bootstrap_server.cpp
@@ -670,7 +670,7 @@ public:
 			debug_assert (!nano::validate_message (response->first, *message_a.query, response->second));
 			auto cookie (connection->node->network.syn_cookies.assign (nano::transport::map_tcp_to_endpoint (connection->remote_endpoint)));
 			nano::node_id_handshake response_message (cookie, response);
-			auto shared_const_buffer = response_message.to_shared_const_buffer ();
+			auto shared_const_buffer = response_message.to_shared_const_buffer (connection->node->ledger.cache.epoch_2_started);
 			connection->socket->async_write (shared_const_buffer, [connection = std::weak_ptr<nano::bootstrap_server> (connection)] (boost::system::error_code const & ec, size_t size_a) {
 				if (auto connection_l = connection.lock ())
 				{

--- a/nano/node/common.cpp
+++ b/nano/node/common.cpp
@@ -64,13 +64,13 @@ nano::message_header::message_header (bool & error_a, nano::stream & stream_a)
 	}
 }
 
-void nano::message_header::serialize (nano::stream & stream_a) const
+void nano::message_header::serialize (nano::stream & stream_a, bool use_epoch_2_min_version_a) const
 {
 	static nano::network_params network_params;
 	nano::write (stream_a, network_params.header_magic_number);
 	nano::write (stream_a, version_max);
 	nano::write (stream_a, version_using);
-	nano::write (stream_a, get_protocol_constants ().protocol_version_min ());
+	nano::write (stream_a, get_protocol_constants ().protocol_version_min (use_epoch_2_min_version_a));
 	nano::write (stream_a, type);
 	nano::write (stream_a, static_cast<uint16_t> (extensions.to_ullong ()));
 }
@@ -120,17 +120,17 @@ nano::message::message (nano::message_header const & header_a) :
 {
 }
 
-std::shared_ptr<std::vector<uint8_t>> nano::message::to_bytes () const
+std::shared_ptr<std::vector<uint8_t>> nano::message::to_bytes (bool use_epoch_2_min_version_a) const
 {
 	auto bytes = std::make_shared<std::vector<uint8_t>> ();
 	nano::vectorstream stream (*bytes);
-	serialize (stream);
+	serialize (stream, use_epoch_2_min_version_a);
 	return bytes;
 }
 
-nano::shared_const_buffer nano::message::to_shared_const_buffer () const
+nano::shared_const_buffer nano::message::to_shared_const_buffer (bool use_epoch_2_min_version_a) const
 {
-	return shared_const_buffer (to_bytes ());
+	return shared_const_buffer (to_bytes (use_epoch_2_min_version_a));
 }
 
 nano::block_type nano::message_header::block_type () const
@@ -341,7 +341,8 @@ nano::message_parser::message_parser (nano::network_filter & publish_filter_a, n
 	vote_uniquer (vote_uniquer_a),
 	visitor (visitor_a),
 	pool (pool_a),
-	status (parse_status::success)
+	status (parse_status::success),
+	use_epoch_2_min_version (use_epoch_2_min_version_a)
 {
 }
 
@@ -357,7 +358,7 @@ void nano::message_parser::deserialize_buffer (uint8_t const * buffer_a, size_t 
 		nano::message_header header (error, stream);
 		if (!error)
 		{
-			if (header.version_using < get_protocol_constants ().protocol_version_min ())
+			if (header.version_using < get_protocol_constants ().protocol_version_min (use_epoch_2_min_version))
 			{
 				status = parse_status::outdated_version;
 			}
@@ -581,9 +582,9 @@ void nano::keepalive::visit (nano::message_visitor & visitor_a) const
 	visitor_a.keepalive (*this);
 }
 
-void nano::keepalive::serialize (nano::stream & stream_a) const
+void nano::keepalive::serialize (nano::stream & stream_a, bool use_epoch_2_min_version_a) const
 {
-	header.serialize (stream_a);
+	header.serialize (stream_a, use_epoch_2_min_version_a);
 	for (auto i (peers.begin ()), j (peers.end ()); i != j; ++i)
 	{
 		debug_assert (i->address ().is_v6 ());
@@ -635,10 +636,10 @@ nano::publish::publish (std::shared_ptr<nano::block> const & block_a) :
 	header.block_type_set (block->type ());
 }
 
-void nano::publish::serialize (nano::stream & stream_a) const
+void nano::publish::serialize (nano::stream & stream_a, bool use_epoch_2_min_version_a) const
 {
 	debug_assert (block != nullptr);
-	header.serialize (stream_a);
+	header.serialize (stream_a, use_epoch_2_min_version_a);
 	block->serialize (stream_a);
 }
 
@@ -702,9 +703,9 @@ void nano::confirm_req::visit (nano::message_visitor & visitor_a) const
 	visitor_a.confirm_req (*this);
 }
 
-void nano::confirm_req::serialize (nano::stream & stream_a) const
+void nano::confirm_req::serialize (nano::stream & stream_a, bool use_epoch_2_min_version_a) const
 {
-	header.serialize (stream_a);
+	header.serialize (stream_a, use_epoch_2_min_version_a);
 	if (header.block_type () == nano::block_type::not_a_block)
 	{
 		debug_assert (!roots_hashes.empty ());
@@ -828,10 +829,10 @@ nano::confirm_ack::confirm_ack (std::shared_ptr<nano::vote> const & vote_a) :
 	}
 }
 
-void nano::confirm_ack::serialize (nano::stream & stream_a) const
+void nano::confirm_ack::serialize (nano::stream & stream_a, bool use_epoch_2_min_version_a) const
 {
 	debug_assert (header.block_type () == nano::block_type::not_a_block || header.block_type () == nano::block_type::send || header.block_type () == nano::block_type::receive || header.block_type () == nano::block_type::open || header.block_type () == nano::block_type::change || header.block_type () == nano::block_type::state);
-	header.serialize (stream_a);
+	header.serialize (stream_a, use_epoch_2_min_version_a);
 	vote->serialize (stream_a, header.block_type ());
 }
 
@@ -874,9 +875,9 @@ nano::frontier_req::frontier_req (bool & error_a, nano::stream & stream_a, nano:
 	}
 }
 
-void nano::frontier_req::serialize (nano::stream & stream_a) const
+void nano::frontier_req::serialize (nano::stream & stream_a, bool use_epoch_2_min_version_a) const
 {
-	header.serialize (stream_a);
+	header.serialize (stream_a, use_epoch_2_min_version_a);
 	write (stream_a, start.bytes);
 	write (stream_a, age);
 	write (stream_a, count);
@@ -929,7 +930,7 @@ void nano::bulk_pull::visit (nano::message_visitor & visitor_a) const
 	visitor_a.bulk_pull (*this);
 }
 
-void nano::bulk_pull::serialize (nano::stream & stream_a) const
+void nano::bulk_pull::serialize (nano::stream & stream_a, bool use_epoch_2_min_version_a) const
 {
 	/*
 	 * Ensure the "count_present" flag is set if there
@@ -941,7 +942,7 @@ void nano::bulk_pull::serialize (nano::stream & stream_a) const
 	 */
 	debug_assert ((count == 0 && !is_count_present ()) || (count != 0 && is_count_present ()));
 
-	header.serialize (stream_a);
+	header.serialize (stream_a, use_epoch_2_min_version_a);
 	write (stream_a, start);
 	write (stream_a, end);
 
@@ -1025,9 +1026,9 @@ void nano::bulk_pull_account::visit (nano::message_visitor & visitor_a) const
 	visitor_a.bulk_pull_account (*this);
 }
 
-void nano::bulk_pull_account::serialize (nano::stream & stream_a) const
+void nano::bulk_pull_account::serialize (nano::stream & stream_a, bool use_epoch_2_min_version_a) const
 {
-	header.serialize (stream_a);
+	header.serialize (stream_a, use_epoch_2_min_version_a);
 	write (stream_a, account);
 	write (stream_a, minimum_amount);
 	write (stream_a, flags);
@@ -1067,9 +1068,9 @@ bool nano::bulk_push::deserialize (nano::stream & stream_a)
 	return false;
 }
 
-void nano::bulk_push::serialize (nano::stream & stream_a) const
+void nano::bulk_push::serialize (nano::stream & stream_a, bool use_epoch_2_min_version_a) const
 {
-	header.serialize (stream_a);
+	header.serialize (stream_a, use_epoch_2_min_version_a);
 }
 
 void nano::bulk_push::visit (nano::message_visitor & visitor_a) const
@@ -1093,9 +1094,9 @@ bool nano::telemetry_req::deserialize (nano::stream & stream_a)
 	return false;
 }
 
-void nano::telemetry_req::serialize (nano::stream & stream_a) const
+void nano::telemetry_req::serialize (nano::stream & stream_a, bool use_epoch_2_min_version_a) const
 {
-	header.serialize (stream_a);
+	header.serialize (stream_a, use_epoch_2_min_version_a);
 }
 
 void nano::telemetry_req::visit (nano::message_visitor & visitor_a) const
@@ -1126,9 +1127,9 @@ nano::telemetry_ack::telemetry_ack (nano::telemetry_data const & telemetry_data_
 	header.extensions |= std::bitset<16> (static_cast<unsigned long long> (telemetry_data::size) + telemetry_data_a.unknown_data.size ());
 }
 
-void nano::telemetry_ack::serialize (nano::stream & stream_a) const
+void nano::telemetry_ack::serialize (nano::stream & stream_a, bool use_epoch_2_min_version_a) const
 {
-	header.serialize (stream_a);
+	header.serialize (stream_a, use_epoch_2_min_version_a);
 	if (!is_empty_payload ())
 	{
 		data.serialize (stream_a);
@@ -1379,9 +1380,9 @@ nano::node_id_handshake::node_id_handshake (boost::optional<nano::uint256_union>
 	}
 }
 
-void nano::node_id_handshake::serialize (nano::stream & stream_a) const
+void nano::node_id_handshake::serialize (nano::stream & stream_a, bool use_epoch_2_min_version_a) const
 {
-	header.serialize (stream_a);
+	header.serialize (stream_a, use_epoch_2_min_version_a);
 	if (query)
 	{
 		write (stream_a, *query);

--- a/nano/node/common.hpp
+++ b/nano/node/common.hpp
@@ -189,7 +189,7 @@ class message_header final
 public:
 	explicit message_header (nano::message_type);
 	message_header (bool &, nano::stream &);
-	void serialize (nano::stream &) const;
+	void serialize (nano::stream &, bool) const;
 	bool deserialize (nano::stream &);
 	nano::block_type block_type () const;
 	void block_type_set (nano::block_type);
@@ -230,10 +230,10 @@ public:
 	explicit message (nano::message_type);
 	explicit message (nano::message_header const &);
 	virtual ~message () = default;
-	virtual void serialize (nano::stream &) const = 0;
+	virtual void serialize (nano::stream &, bool) const = 0;
 	virtual void visit (nano::message_visitor &) const = 0;
-	std::shared_ptr<std::vector<uint8_t>> to_bytes () const;
-	nano::shared_const_buffer to_shared_const_buffer () const;
+	std::shared_ptr<std::vector<uint8_t>> to_bytes (bool) const;
+	nano::shared_const_buffer to_shared_const_buffer (bool) const;
 
 	nano::message_header header;
 };
@@ -257,7 +257,7 @@ public:
 		outdated_version,
 		duplicate_publish_message
 	};
-	message_parser (nano::network_filter &, nano::block_uniquer &, nano::vote_uniquer &, nano::message_visitor &, nano::work_pool &);
+	message_parser (nano::network_filter &, nano::block_uniquer &, nano::vote_uniquer &, nano::message_visitor &, nano::work_pool &, bool);
 	void deserialize_buffer (uint8_t const *, size_t);
 	void deserialize_keepalive (nano::stream &, nano::message_header const &);
 	void deserialize_publish (nano::stream &, nano::message_header const &, nano::uint128_t const & = 0);
@@ -273,6 +273,7 @@ public:
 	nano::message_visitor & visitor;
 	nano::work_pool & pool;
 	parse_status status;
+	bool use_epoch_2_min_version;
 	std::string status_string ();
 	static const size_t max_safe_udp_message_size;
 };
@@ -282,7 +283,7 @@ public:
 	keepalive ();
 	keepalive (bool &, nano::stream &, nano::message_header const &);
 	void visit (nano::message_visitor &) const override;
-	void serialize (nano::stream &) const override;
+	void serialize (nano::stream &, bool) const override;
 	bool deserialize (nano::stream &);
 	bool operator== (nano::keepalive const &) const;
 	std::array<nano::endpoint, 8> peers;
@@ -294,7 +295,7 @@ public:
 	publish (bool &, nano::stream &, nano::message_header const &, nano::uint128_t const & = 0, nano::block_uniquer * = nullptr);
 	explicit publish (std::shared_ptr<nano::block> const &);
 	void visit (nano::message_visitor &) const override;
-	void serialize (nano::stream &) const override;
+	void serialize (nano::stream &, bool) const override;
 	bool deserialize (nano::stream &, nano::block_uniquer * = nullptr);
 	bool operator== (nano::publish const &) const;
 	std::shared_ptr<nano::block> block;
@@ -307,7 +308,7 @@ public:
 	explicit confirm_req (std::shared_ptr<nano::block> const &);
 	confirm_req (std::vector<std::pair<nano::block_hash, nano::root>> const &);
 	confirm_req (nano::block_hash const &, nano::root const &);
-	void serialize (nano::stream &) const override;
+	void serialize (nano::stream &, bool) const override;
 	bool deserialize (nano::stream &, nano::block_uniquer * = nullptr);
 	void visit (nano::message_visitor &) const override;
 	bool operator== (nano::confirm_req const &) const;
@@ -321,7 +322,7 @@ class confirm_ack final : public message
 public:
 	confirm_ack (bool &, nano::stream &, nano::message_header const &, nano::vote_uniquer * = nullptr);
 	explicit confirm_ack (std::shared_ptr<nano::vote> const &);
-	void serialize (nano::stream &) const override;
+	void serialize (nano::stream &, bool) const override;
 	void visit (nano::message_visitor &) const override;
 	bool operator== (nano::confirm_ack const &) const;
 	std::shared_ptr<nano::vote> vote;
@@ -332,7 +333,7 @@ class frontier_req final : public message
 public:
 	frontier_req ();
 	frontier_req (bool &, nano::stream &, nano::message_header const &);
-	void serialize (nano::stream &) const override;
+	void serialize (nano::stream &, bool) const override;
 	bool deserialize (nano::stream &);
 	void visit (nano::message_visitor &) const override;
 	bool operator== (nano::frontier_req const &) const;
@@ -391,7 +392,7 @@ class telemetry_req final : public message
 public:
 	telemetry_req ();
 	explicit telemetry_req (nano::message_header const &);
-	void serialize (nano::stream &) const override;
+	void serialize (nano::stream &, bool) const override;
 	bool deserialize (nano::stream &);
 	void visit (nano::message_visitor &) const override;
 };
@@ -401,7 +402,7 @@ public:
 	telemetry_ack ();
 	telemetry_ack (bool &, nano::stream &, nano::message_header const &);
 	explicit telemetry_ack (telemetry_data const &);
-	void serialize (nano::stream &) const override;
+	void serialize (nano::stream &, bool) const override;
 	void visit (nano::message_visitor &) const override;
 	bool deserialize (nano::stream &);
 	uint16_t size () const;
@@ -416,7 +417,7 @@ public:
 	using count_t = uint32_t;
 	bulk_pull ();
 	bulk_pull (bool &, nano::stream &, nano::message_header const &);
-	void serialize (nano::stream &) const override;
+	void serialize (nano::stream &, bool) const override;
 	bool deserialize (nano::stream &);
 	void visit (nano::message_visitor &) const override;
 	nano::hash_or_account start{ 0 };
@@ -433,7 +434,7 @@ class bulk_pull_account final : public message
 public:
 	bulk_pull_account ();
 	bulk_pull_account (bool &, nano::stream &, nano::message_header const &);
-	void serialize (nano::stream &) const override;
+	void serialize (nano::stream &, bool) const override;
 	bool deserialize (nano::stream &);
 	void visit (nano::message_visitor &) const override;
 	nano::account account;
@@ -446,7 +447,7 @@ class bulk_push final : public message
 public:
 	bulk_push ();
 	explicit bulk_push (nano::message_header const &);
-	void serialize (nano::stream &) const override;
+	void serialize (nano::stream &, bool) const override;
 	bool deserialize (nano::stream &);
 	void visit (nano::message_visitor &) const override;
 };
@@ -455,7 +456,7 @@ class node_id_handshake final : public message
 public:
 	node_id_handshake (bool &, nano::stream &, nano::message_header const &);
 	node_id_handshake (boost::optional<nano::uint256_union>, boost::optional<std::pair<nano::account, nano::signature>>);
-	void serialize (nano::stream &) const override;
+	void serialize (nano::stream &, bool) const override;
 	bool deserialize (nano::stream &);
 	void visit (nano::message_visitor &) const override;
 	bool operator== (nano::node_id_handshake const &) const;

--- a/nano/node/network.cpp
+++ b/nano/node/network.cpp
@@ -685,11 +685,11 @@ nano::tcp_endpoint nano::network::bootstrap_peer (bool lazy_bootstrap)
 	bool use_udp_peer (nano::random_pool::generate_word32 (0, 1));
 	if (use_udp_peer || tcp_channels.size () == 0)
 	{
-		result = udp_channels.bootstrap_peer (node.network_params.protocol.protocol_version_min ());
+		result = udp_channels.bootstrap_peer (node.network_params.protocol.protocol_version_min (node.ledger.cache.epoch_2_started));
 	}
 	if (result == nano::tcp_endpoint (boost::asio::ip::address_v6::any (), 0))
 	{
-		result = tcp_channels.bootstrap_peer (node.network_params.protocol.protocol_version_min ());
+		result = tcp_channels.bootstrap_peer (node.network_params.protocol.protocol_version_min (node.ledger.cache.epoch_2_started));
 	}
 	return result;
 }
@@ -779,6 +779,18 @@ float nano::network::size_sqrt () const
 bool nano::network::empty () const
 {
 	return size () == 0;
+}
+
+void nano::network::erase_below_version (uint8_t cutoff_version_a)
+{
+	std::vector<std::shared_ptr<nano::transport::channel>> channels_to_remove;
+	tcp_channels.list_below_version (channels_to_remove, cutoff_version_a);
+	udp_channels.list_below_version (channels_to_remove, cutoff_version_a);
+	for (auto const & channel_to_remove : channels_to_remove)
+	{
+		debug_assert (channel_to_remove->get_network_version () < cutoff_version_a);
+		erase (*channel_to_remove);
+	}
 }
 
 void nano::network::erase (nano::transport::channel const & channel_a)

--- a/nano/node/network.hpp
+++ b/nano/node/network.hpp
@@ -180,6 +180,7 @@ public:
 	bool empty () const;
 	void erase (nano::transport::channel const &);
 	void set_bandwidth_params (double, size_t);
+	void erase_below_version (uint8_t);
 	nano::message_buffer_manager buffer_container;
 	boost::asio::ip::udp::resolver resolver;
 	std::vector<boost::thread> packet_processing_threads;

--- a/nano/node/node.cpp
+++ b/nano/node/node.cpp
@@ -85,6 +85,7 @@ nano::node::node (boost::asio::io_context & io_ctx_a, uint16_t peering_port_a, b
 }
 
 nano::node::node (boost::asio::io_context & io_ctx_a, boost::filesystem::path const & application_path_a, nano::node_config const & config_a, nano::work_pool & work_a, nano::node_flags flags_a, unsigned seq) :
+<<<<<<< HEAD
 	write_database_queue (!flags_a.force_use_write_database_queue && (config_a.rocksdb_config.enable || nano::using_rocksdb_in_tests ())),
 	io_ctx (io_ctx_a),
 	node_initialized_latch (1),
@@ -122,6 +123,50 @@ nano::node::node (boost::asio::io_context & io_ctx_a, boost::filesystem::path co
 	wallets (wallets_store.init_error (), *this),
 	startup_time (std::chrono::steady_clock::now ()),
 	node_seq (seq)
+
+write_database_queue (!flags_a.force_use_write_database_queue && (config_a.rocksdb_config.enable || nano::using_rocksdb_in_tests ())),
+io_ctx (io_ctx_a),
+node_initialized_latch (1),
+config (config_a),
+stats (config.stat_config),
+workers (std::max (3u, config.io_threads / 2), nano::thread_role::name::worker),
+flags (flags_a),
+work (work_a),
+distributed_work (*this),
+logger (config_a.logging.min_time_between_log_output),
+store_impl (nano::make_store (logger, application_path_a, flags.read_only, true, config_a.rocksdb_config, config_a.diagnostics_config.txn_tracking, config_a.block_processor_batch_max_time, config_a.lmdb_config, config_a.backup_before_upgrade)),
+store (*store_impl),
+wallets_store_impl (std::make_unique<nano::mdb_wallets_store> (application_path_a / "wallets.ldb", config_a.lmdb_config)),
+wallets_store (*wallets_store_impl),
+gap_cache (*this),
+ledger (store, stats, flags_a.generate_cache, [this]() { this->network.erase_below_version (network_params.protocol.protocol_version_min (true)); }),
+checker (config.signature_checker_threads),
+network (*this, config.peering_port),
+telemetry (std::make_shared<nano::telemetry> (network, workers, observers.telemetry, stats, network_params, flags.disable_ongoing_telemetry_requests)),
+bootstrap_initiator (*this),
+bootstrap (config.peering_port, *this),
+application_path (application_path_a),
+port_mapping (*this),
+rep_crawler (*this),
+vote_processor (checker, active, observers, stats, config, flags, logger, online_reps, rep_crawler, ledger, network_params),
+warmed_up (0),
+block_processor (*this, write_database_queue),
+// clang-format off
+block_processor_thread ([this]() {
+	nano::thread_role::set (nano::thread_role::name::block_processing);
+	this->block_processor.process_blocks ();
+}),
+// clang-format on
+online_reps (ledger, config),
+history{ config.network_params.voting },
+vote_uniquer (block_uniquer),
+confirmation_height_processor (ledger, write_database_queue, config.conf_height_processor_batch_min_time, config.logging, logger, node_initialized_latch, flags.confirmation_height_processor_mode),
+active (*this, confirmation_height_processor),
+aggregator (network_params.network, config, stats, active.generator, history, ledger, wallets, active),
+wallets (wallets_store.init_error (), *this),
+startup_time (std::chrono::steady_clock::now ()),
+node_seq (seq)
+>>>>>>> parent of 9690113b (Remove epoch2 started code (#3038))
 {
 	if (!init_error ())
 	{
@@ -1112,7 +1157,7 @@ uint64_t nano::node::default_difficulty (nano::work_version const version_a) con
 	switch (version_a)
 	{
 		case nano::work_version::work_1:
-			result = nano::work_threshold_base (version_a);
+			result = ledger.cache.epoch_2_started ? nano::work_threshold_base (version_a) : network_params.network.publish_thresholds.epoch_1;
 			break;
 		default:
 			debug_assert (false && "Invalid version specified to default_difficulty");
@@ -1126,7 +1171,7 @@ uint64_t nano::node::default_receive_difficulty (nano::work_version const versio
 	switch (version_a)
 	{
 		case nano::work_version::work_1:
-			result = network_params.network.publish_thresholds.epoch_2_receive;
+			result = ledger.cache.epoch_2_started ? network_params.network.publish_thresholds.epoch_2_receive : network_params.network.publish_thresholds.epoch_1;
 			break;
 		default:
 			debug_assert (false && "Invalid version specified to default_receive_difficulty");
@@ -1814,6 +1859,7 @@ nano::node_flags const & nano::inactive_node_flag_defaults ()
 	node_flags.generate_cache.cemented_count = false;
 	node_flags.generate_cache.unchecked_count = false;
 	node_flags.generate_cache.account_count = false;
+	node_flags.generate_cache.epoch_2 = false;
 	node_flags.disable_bootstrap_listener = true;
 	node_flags.disable_tcp_realtime = true;
 	return node_flags;

--- a/nano/node/repcrawler.cpp
+++ b/nano/node/repcrawler.cpp
@@ -326,7 +326,7 @@ void nano::rep_crawler::update_weights ()
 
 std::vector<nano::representative> nano::rep_crawler::representatives (size_t count_a, nano::uint128_t const weight_a, boost::optional<decltype (nano::protocol_constants::protocol_version)> const & opt_version_min_a)
 {
-	auto version_min (opt_version_min_a.value_or (node.network_params.protocol.protocol_version_min ()));
+	auto version_min (opt_version_min_a.value_or (node.network_params.protocol.protocol_version_min (node.ledger.cache.epoch_2_started)));
 	std::vector<representative> result;
 	nano::lock_guard<nano::mutex> lock (probable_reps_mutex);
 	for (auto i (probable_reps.get<tag_weight> ().begin ()), n (probable_reps.get<tag_weight> ().end ()); i != n && result.size () < count_a; ++i)

--- a/nano/node/telemetry.cpp
+++ b/nano/node/telemetry.cpp
@@ -175,7 +175,7 @@ void nano::telemetry::ongoing_req_all_peers (std::chrono::milliseconds next_requ
 
 				{
 					// Copy peers to the multi index container so can get better asymptotic complexity in future operations
-					auto temp_peers = this_l->network.list (std::numeric_limits<size_t>::max ());
+					auto temp_peers = this_l->network.list (std::numeric_limits<size_t>::max (), this_l->network_params.protocol.telemetry_protocol_version_min);
 					peers.insert (temp_peers.begin (), temp_peers.end ());
 				}
 
@@ -276,7 +276,7 @@ void nano::telemetry::get_metrics_single_peer_async (std::shared_ptr<nano::trans
 
 	if (!stopped)
 	{
-		if (channel_a)
+		if (channel_a && (channel_a->get_network_version () >= network_params.protocol.telemetry_protocol_version_min))
 		{
 			auto add_callback_async = [&workers = this->workers, &callback_a] (telemetry_data const & telemetry_data_a, nano::endpoint const & endpoint_a) {
 				telemetry_data_response telemetry_data_response_l{ telemetry_data_a, endpoint_a, false };
@@ -342,6 +342,9 @@ nano::telemetry_data_response nano::telemetry::get_metrics_single_peer (std::sha
 
 void nano::telemetry::fire_request_message (std::shared_ptr<nano::transport::channel> const & channel_a)
 {
+	// Fire off a telemetry request to all passed in channels
+	debug_assert (channel_a->get_network_version () >= network_params.protocol.telemetry_protocol_version_min);
+
 	uint64_t round_l;
 	{
 		auto it = recent_or_initial_request_telemetry_data.find (channel_a->get_endpoint ());

--- a/nano/node/transport/tcp.cpp
+++ b/nano/node/transport/tcp.cpp
@@ -290,7 +290,7 @@ void nano::transport::tcp_channels::process_messages ()
 
 void nano::transport::tcp_channels::process_message (nano::message const & message_a, nano::tcp_endpoint const & endpoint_a, nano::account const & node_id_a, std::shared_ptr<nano::socket> const & socket_a, nano::bootstrap_server_type type_a)
 {
-	if (!stopped && message_a.header.version_using >= protocol_constants ().protocol_version_min ())
+	if (!stopped && message_a.header.version_using >= protocol_constants ().protocol_version_min (node.ledger.cache.epoch_2_started))
 	{
 		auto channel (node.network.find_channel (nano::transport::map_tcp_to_endpoint (endpoint_a)));
 		if (channel)
@@ -432,7 +432,7 @@ void nano::transport::tcp_channels::purge (std::chrono::steady_clock::time_point
 	attempts.get<last_attempt_tag> ().erase (attempts.get<last_attempt_tag> ().begin (), attempts_cutoff);
 
 	// Check if any tcp channels belonging to old protocol versions which may still be alive due to async operations
-	auto lower_bound = channels.get<version_tag> ().lower_bound (node.network_params.protocol.protocol_version_min ());
+	auto lower_bound = channels.get<version_tag> ().lower_bound (node.network_params.protocol.protocol_version_min (node.ledger.cache.epoch_2_started));
 	channels.get<version_tag> ().erase (channels.get<version_tag> ().begin (), lower_bound);
 
 	// Cleanup any sockets which may still be existing from failed node id handshakes
@@ -466,7 +466,7 @@ void nano::transport::tcp_channels::ongoing_keepalive ()
 		size_t random_count (std::min (static_cast<size_t> (6), static_cast<size_t> (std::ceil (std::sqrt (node.network.udp_channels.size ())))));
 		for (auto i (0); i <= random_count; ++i)
 		{
-			auto tcp_endpoint (node.network.udp_channels.bootstrap_peer (node.network_params.protocol.protocol_version_min ()));
+			auto tcp_endpoint (node.network.udp_channels.bootstrap_peer (node.network_params.protocol.protocol_version_min (node.ledger.cache.epoch_2_started)));
 			if (tcp_endpoint != invalid_endpoint && find_channel (tcp_endpoint) == nullptr && !node.network.excluded_peers.check (tcp_endpoint))
 			{
 				start_tcp (nano::transport::map_tcp_to_endpoint (tcp_endpoint));
@@ -571,7 +571,7 @@ void nano::transport::tcp_channels::start_tcp (nano::endpoint const & endpoint_a
 				// TCP node ID handshake
 				auto cookie (node_l->network.syn_cookies.assign (endpoint_a));
 				nano::node_id_handshake message (cookie, boost::none);
-				auto bytes = message.to_shared_const_buffer ();
+				auto bytes = message.to_shared_const_buffer (node_l->ledger.cache.epoch_2_started);
 				if (node_l->config.logging.network_node_id_handshake_logging ())
 				{
 					node_l->logger.try_log (boost::str (boost::format ("Node ID handshake request sent with node ID %1% to %2%: query %3%") % node_l->node_id.pub.to_node_id () % endpoint_a % (*cookie).to_string ()));
@@ -646,7 +646,7 @@ void nano::transport::tcp_channels::start_tcp_receive_node_id (std::shared_ptr<n
 					nano::message_header header (error, stream);
 					if (!error && header.type == nano::message_type::node_id_handshake)
 					{
-						if (header.version_using >= node_l->network_params.protocol.protocol_version_min ())
+						if (header.version_using >= node_l->network_params.protocol.protocol_version_min (node_l->ledger.cache.epoch_2_started))
 						{
 							nano::node_id_handshake message (error, stream, header);
 							if (!error && message.response && message.query)
@@ -670,7 +670,7 @@ void nano::transport::tcp_channels::start_tcp_receive_node_id (std::shared_ptr<n
 									channel_a->set_last_packet_received (std::chrono::steady_clock::now ());
 									boost::optional<std::pair<nano::account, nano::signature>> response (std::make_pair (node_l->node_id.pub, nano::sign_message (node_l->node_id.prv, node_l->node_id.pub, *message.query)));
 									nano::node_id_handshake response_message (boost::none, response);
-									auto bytes = response_message.to_shared_const_buffer ();
+									auto bytes = response_message.to_shared_const_buffer (node_l->ledger.cache.epoch_2_started);
 									if (node_l->config.logging.network_node_id_handshake_logging ())
 									{
 										node_l->logger.try_log (boost::str (boost::format ("Node ID handshake response sent with node ID %1% to %2%: query %3%") % node_l->node_id.pub.to_node_id () % endpoint_a % (*message.query).to_string ()));

--- a/nano/node/transport/transport.cpp
+++ b/nano/node/transport/transport.cpp
@@ -104,7 +104,7 @@ void nano::transport::channel::send (nano::message const & message_a, std::funct
 {
 	callback_visitor visitor;
 	message_a.visit (visitor);
-	auto buffer (message_a.to_shared_const_buffer ());
+	auto buffer (message_a.to_shared_const_buffer (node.ledger.cache.epoch_2_started));
 	auto detail (visitor.result);
 	auto is_droppable_by_limiter = drop_policy_a == nano::buffer_drop_policy::limiter;
 	auto should_drop (node.network.limiter.should_drop (buffer.size ()));

--- a/nano/node/transport/udp.cpp
+++ b/nano/node/transport/udp.cpp
@@ -538,7 +538,7 @@ void nano::transport::udp_channels::receive_action (nano::message_buffer * data_
 	if (allowed_sender)
 	{
 		udp_message_visitor visitor (node, data_a->endpoint);
-		nano::message_parser parser (node.network.publish_filter, node.block_uniquer, node.vote_uniquer, visitor, node.work);
+		nano::message_parser parser (node.network.publish_filter, node.block_uniquer, node.vote_uniquer, visitor, node.work, node.ledger.cache.epoch_2_started);
 		parser.deserialize_buffer (data_a->buffer, data_a->size);
 		if (parser.status == nano::message_parser::parse_status::success)
 		{

--- a/nano/rpc_test/rpc.cpp
+++ b/nano/rpc_test/rpc.cpp
@@ -2614,6 +2614,63 @@ TEST (rpc, work_generate_multiplier)
 	}
 }
 
+TEST (rpc, work_generate_epoch_2)
+{
+	nano::system system;
+	auto node = add_ipc_enabled_node (system);
+	auto epoch1 = system.upgrade_genesis_epoch (*node, nano::epoch::epoch_1);
+	ASSERT_NE (nullptr, epoch1);
+	scoped_io_thread_name_change scoped_thread_name_io;
+	nano::node_rpc_config node_rpc_config;
+	nano::ipc::ipc_server ipc_server (*node, node_rpc_config);
+	nano::rpc_config rpc_config (nano::get_available_port (), true);
+	rpc_config.rpc_process.ipc_port = node->config.ipc_config.transport_tcp.port;
+	nano::ipc_rpc_processor ipc_rpc_processor (system.io_ctx, rpc_config);
+	nano::rpc rpc (system.io_ctx, rpc_config, ipc_rpc_processor);
+	rpc.start ();
+	boost::property_tree::ptree request;
+	auto verify_response = [node, &rpc, &system](auto & request, nano::block_hash const & hash, uint64_t & out_difficulty) {
+		request.put ("hash", hash.to_string ());
+		test_response response (request, rpc.config.port, system.io_ctx);
+		ASSERT_TIMELY (5s, response.status != 0);
+		ASSERT_EQ (200, response.status);
+		auto work_text (response.json.get<std::string> ("work"));
+		uint64_t work{ 0 };
+		ASSERT_FALSE (nano::from_string_hex (work_text, work));
+		out_difficulty = nano::work_difficulty (nano::work_version::work_1, hash, work);
+	};
+	request.put ("action", "work_generate");
+	// Before upgrading to epoch 2 should use epoch_1 difficulty as default
+	{
+		unsigned const max_tries = 30;
+		uint64_t difficulty{ 0 };
+		unsigned tries = 0;
+		while (++tries < max_tries)
+		{
+			verify_response (request, epoch1->hash (), difficulty);
+			if (difficulty < node->network_params.network.publish_thresholds.base)
+			{
+				break;
+			}
+		}
+		ASSERT_LT (tries, max_tries);
+	}
+	// After upgrading, should always use the higher difficulty by default
+	ASSERT_EQ (node->network_params.network.publish_thresholds.epoch_2, node->network_params.network.publish_thresholds.base);
+	scoped_thread_name_io.reset ();
+	auto epoch2 = system.upgrade_genesis_epoch (*node, nano::epoch::epoch_2);
+	ASSERT_NE (nullptr, epoch2);
+	scoped_thread_name_io.renew ();
+	{
+		for (auto i = 0; i < 5; ++i)
+		{
+			uint64_t difficulty{ 0 };
+			verify_response (request, epoch1->hash (), difficulty);
+			ASSERT_GE (difficulty, node->network_params.network.publish_thresholds.base);
+		}
+	}
+}
+
 TEST (rpc, work_generate_block_high)
 {
 	nano::system system;
@@ -3683,13 +3740,13 @@ TEST (rpc, work_validate_epoch_2)
 		ASSERT_TIMELY (5s, response.status != 0);
 		ASSERT_EQ (200, response.status);
 		ASSERT_EQ (0, response.json.count ("valid"));
-		ASSERT_FALSE (response.json.get<bool> ("valid_all"));
+		ASSERT_TRUE (response.json.get<bool> ("valid_all"));
 		ASSERT_TRUE (response.json.get<bool> ("valid_receive"));
 		std::string difficulty_text (response.json.get<std::string> ("difficulty"));
 		uint64_t difficulty{ 0 };
 		ASSERT_FALSE (nano::from_string_hex (difficulty_text, difficulty));
 		double multiplier (response.json.get<double> ("multiplier"));
-		ASSERT_NEAR (multiplier, nano::difficulty::to_multiplier (difficulty, node->network_params.network.publish_thresholds.epoch_2), 1e-6);
+		ASSERT_NEAR (multiplier, nano::difficulty::to_multiplier (difficulty, node->network_params.network.publish_thresholds.epoch_1), 1e-6);
 	};
 	// After upgrading, the higher difficulty is used to validate and calculate the multiplier
 	scoped_thread_name_io.reset ();
@@ -5533,14 +5590,7 @@ TEST (rpc, block_create_state_request_work)
 
 	// Test work generation for state blocks both with and without previous (in the latter
 	// case, the account will be used for work generation)
-	std::unique_ptr<nano::state_block> epoch2;
-	{
-		nano::system system (1);
-		system.upgrade_genesis_epoch (*system.nodes.front (), nano::epoch::epoch_1);
-		epoch2 = system.upgrade_genesis_epoch (*system.nodes.front (), nano::epoch::epoch_2);
-	}
-
-	std::vector<std::string> previous_test_input{ epoch2->hash ().to_string (), std::string ("0") };
+	std::vector<std::string> previous_test_input{ genesis.hash ().to_string (), std::string ("0") };
 	for (auto previous : previous_test_input)
 	{
 		nano::system system;
@@ -6938,6 +6988,8 @@ TEST (rpc, active_difficulty)
 {
 	nano::system system;
 	auto node = add_ipc_enabled_node (system);
+	// "Start" epoch 2
+	node->ledger.cache.epoch_2_started = true;
 	ASSERT_EQ (node->default_difficulty (nano::work_version::work_1), node->network_params.network.publish_thresholds.epoch_2);
 	scoped_io_thread_name_change scoped_thread_name_io;
 	nano::node_rpc_config node_rpc_config;

--- a/nano/secure/common.cpp
+++ b/nano/secure/common.cpp
@@ -93,9 +93,9 @@ nano::network_params::network_params (nano::nano_networks network_a) :
 	header_magic_number = network.is_dev_network () ? std::array<uint8_t, 2>{ { 'B', 'Z' } } : network.is_beta_network () ? std::array<uint8_t, 2>{ { 'B', 'Y' } } : network.is_live_network () ? std::array<uint8_t, 2>{ { 'B', 'X' } } : nano::test_magic_number ();
 }
 
-uint8_t nano::protocol_constants::protocol_version_min () const
+uint8_t nano::protocol_constants::protocol_version_min (bool use_epoch_2_min_version_a) const
 {
-	return protocol_version_min_m;
+	return use_epoch_2_min_version_a ? protocol_version_min_epoch_2 : protocol_version_min_pre_epoch_2;
 }
 
 nano::ledger_constants::ledger_constants (nano::network_constants & network_constants) :
@@ -881,4 +881,5 @@ void nano::generate_cache::enable_all ()
 	cemented_count = true;
 	unchecked_count = true;
 	account_count = true;
+	epoch_2 = true;
 }

--- a/nano/secure/common.hpp
+++ b/nano/secure/common.hpp
@@ -352,15 +352,20 @@ public:
 	uint8_t const protocol_version = 0x12;
 
 	/** Minimum accepted protocol version */
-	uint8_t protocol_version_min () const;
+	uint8_t protocol_version_min (bool epoch_2_started) const;
+
+	/** Do not request telemetry metrics to nodes older than this version */
+	uint8_t const telemetry_protocol_version_min = 0x12;
 
 private:
-	/* Minimum protocol version we will establish connections to */
-	uint8_t const protocol_version_min_m = 0x12;
+	/* Minimum protocol version before an epoch 2 block is seen */
+	uint8_t const protocol_version_min_pre_epoch_2 = 0x11;
+	/* Minimum protocol version after an epoch 2 block is seen */
+	uint8_t const protocol_version_min_epoch_2 = 0x12;
 };
 
 // Some places use the decltype of protocol_version instead of protocol_version_min. To keep those checks simpler we check that the decltypes match ignoring differences in const
-static_assert (std::is_same<std::remove_const_t<decltype (protocol_constants ().protocol_version)>, decltype (protocol_constants ().protocol_version_min ())>::value, "protocol_min should match");
+static_assert (std::is_same<std::remove_const_t<decltype (protocol_constants ().protocol_version)>, decltype (protocol_constants ().protocol_version_min (false))>::value, "protocol_min should match");
 
 /** Genesis keys and ledger constants for network variants */
 class ledger_constants
@@ -503,6 +508,7 @@ public:
 	bool cemented_count = true;
 	bool unchecked_count = true;
 	bool account_count = true;
+	bool epoch_2 = true;
 	bool block_count = true;
 
 	void enable_all ();
@@ -518,6 +524,7 @@ public:
 	std::atomic<uint64_t> pruned_count{ 0 };
 	std::atomic<uint64_t> account_count{ 0 };
 	std::atomic<bool> final_votes_confirmation_canary{ false };
+	std::atomic<bool> epoch_2_started{ false };
 };
 
 /* Defines the possible states for an election to stop in */

--- a/nano/secure/ledger.cpp
+++ b/nano/secure/ledger.cpp
@@ -458,6 +458,17 @@ void ledger_processor::epoch_block_impl (nano::state_block & block_a)
 								{
 									ledger.store.frontier_del (transaction, info.head);
 								}
+								if (epoch == nano::epoch::epoch_2)
+								{
+									if (!ledger.cache.epoch_2_started.exchange (true))
+									{
+										// The first epoch 2 block has been seen
+										if (ledger.epoch_2_started_cb)
+										{
+											ledger.epoch_2_started_cb ();
+										}
+									}
+								}
 							}
 						}
 					}
@@ -736,11 +747,11 @@ ledger_processor::ledger_processor (nano::ledger & ledger_a, nano::write_transac
 }
 } // namespace
 
-nano::ledger::ledger (nano::block_store & store_a, nano::stat & stat_a, nano::generate_cache const & generate_cache_a) :
+nano::ledger::ledger (nano::block_store & store_a, nano::stat & stat_a, nano::generate_cache const & generate_cache_a, std::function<void()> epoch_2_started_cb_a) :
 	store (store_a),
 	stats (stat_a),
-	check_bootstrap_weights (true)
-{
+	check_bootstrap_weights (true),
+	epoch_2_started_cb (epoch_2_started_cb_a){
 	if (!store.init_error ())
 	{
 		initialize (generate_cache_a);
@@ -749,19 +760,25 @@ nano::ledger::ledger (nano::block_store & store_a, nano::stat & stat_a, nano::ge
 
 void nano::ledger::initialize (nano::generate_cache const & generate_cache_a)
 {
-	if (generate_cache_a.reps || generate_cache_a.account_count || generate_cache_a.block_count)
+	if (generate_cache_a.reps || generate_cache_a.account_count || generate_cache_a.epoch_2 || generate_cache_a.block_count)
 	{
 		store.accounts_for_each_par (
 		[this] (nano::read_transaction const & /*unused*/, nano::store_iterator<nano::account, nano::account_info> i, nano::store_iterator<nano::account, nano::account_info> n) {
 			uint64_t block_count_l{ 0 };
 			uint64_t account_count_l{ 0 };
 			decltype (this->cache.rep_weights) rep_weights_l;
+			bool epoch_2_started_l{ false };
 			for (; i != n; ++i)
 			{
 				nano::account_info const & info (i->second);
 				block_count_l += info.block_count;
 				++account_count_l;
 				rep_weights_l.representation_add (info.representative, info.balance.number ());
+				epoch_2_started_l = epoch_2_started_l || info.epoch () == nano::epoch::epoch_2;
+			}
+			if (epoch_2_started_l)
+			{
+				this->cache.epoch_2_started.store (true);
 			}
 			this->cache.block_count += block_count_l;
 			this->cache.account_count += account_count_l;

--- a/nano/secure/ledger.hpp
+++ b/nano/secure/ledger.hpp
@@ -26,7 +26,7 @@ public:
 class ledger final
 {
 public:
-	ledger (nano::block_store &, nano::stat &, nano::generate_cache const & = nano::generate_cache ());
+	ledger (nano::block_store &, nano::stat &, nano::generate_cache const & = nano::generate_cache (), std::function<void()> = nullptr);
 	nano::account account (nano::transaction const &, nano::block_hash const &) const;
 	nano::account account_safe (nano::transaction const &, nano::block_hash const &, bool &) const;
 	nano::uint128_t amount (nano::transaction const &, nano::account const &);
@@ -77,6 +77,7 @@ public:
 	uint64_t bootstrap_weight_max_blocks{ 1 };
 	std::atomic<bool> check_bootstrap_weights;
 	bool pruning{ false };
+	std::function<void()> epoch_2_started_cb;
 
 private:
 	void initialize (nano::generate_cache const &);

--- a/nano/slow_test/node.cpp
+++ b/nano/slow_test/node.cpp
@@ -1488,7 +1488,7 @@ TEST (telemetry, many_nodes)
 		ASSERT_LE (data.peer_count, 9U);
 		ASSERT_EQ (data.account_count, 1);
 		ASSERT_TRUE (data.block_count == 2);
-		ASSERT_EQ (data.protocol_version, params.protocol.protocol_version);
+		ASSERT_EQ (data.protocol_version, params.protocol.telemetry_protocol_version_min);
 		ASSERT_GE (data.bandwidth_cap, 100000);
 		ASSERT_LT (data.bandwidth_cap, 100000 + system.nodes.size ());
 		ASSERT_EQ (data.major_version, nano::get_major_node_version ());

--- a/nano/test_common/telemetry.cpp
+++ b/nano/test_common/telemetry.cpp
@@ -9,7 +9,7 @@ void nano::compare_default_telemetry_response_data_excluding_signature (nano::te
 	ASSERT_EQ (telemetry_data_a.cemented_count, 1);
 	ASSERT_EQ (telemetry_data_a.bandwidth_cap, bandwidth_limit_a);
 	ASSERT_EQ (telemetry_data_a.peer_count, 1);
-	ASSERT_EQ (telemetry_data_a.protocol_version, network_params_a.protocol.protocol_version);
+	ASSERT_EQ (telemetry_data_a.protocol_version, network_params_a.protocol.telemetry_protocol_version_min);
 	ASSERT_EQ (telemetry_data_a.unchecked_count, 0);
 	ASSERT_EQ (telemetry_data_a.account_count, 1);
 	ASSERT_LT (telemetry_data_a.uptime, 100);


### PR DESCRIPTION
This reverts commit 9690113b7d23f8d043c3f8a7a97efc1420f57b36.

I resolved all the conflicts since this happened and it seems to be peering and running find now with tcp peers on the old version and cementing blocks.