### PR TITLE
Add external address to UPnP port mapping.

### DIFF
--- a/nano/node/portmapping.cpp
+++ b/nano/node/portmapping.cpp
@@ -107,7 +107,7 @@ void nano::port_mapping::refresh_mapping ()
 		for (auto & protocol : protocols | boost::adaptors::filtered ([] (auto const & p) { return p.enabled; }))
 		{
 			auto upnp_description = std::string ("Banano Node (") + node.network_params.network.get_current_network_as_string () + ")";
-			auto add_port_mapping_error_l (UPNP_AddPortMapping (upnp.urls.controlURL, upnp.data.first.servicetype, config_port_l.c_str (), node_port_l.c_str (), address.to_string ().c_str (), upnp_description.c_str (), protocol.name, nullptr, std::to_string (node.network_params.portmapping.lease_duration.count ()).c_str ()));
+			auto add_port_mapping_error_l (UPNP_AddPortMapping (upnp.urls.controlURL, upnp.data.first.servicetype, config_port_l.c_str (), node_port_l.c_str (), address.to_string ().c_str (), upnp_description.c_str (), protocol.name, protocol.external_address.to_string ().c_str (), std::to_string (node.network_params.portmapping.lease_duration.count ()).c_str ()));
 
 			if (add_port_mapping_error_l == UPNPCOMMAND_SUCCESS)
 			{
@@ -139,7 +139,7 @@ bool nano::port_mapping::check_lost_or_old_mapping ()
 		std::array<char, 6> int_port_l;
 		std::array<char, 16> remaining_mapping_duration_l;
 		remaining_mapping_duration_l.fill (0);
-		auto verify_port_mapping_error_l (UPNP_GetSpecificPortMappingEntry (upnp.urls.controlURL, upnp.data.first.servicetype, config_port_l.c_str (), protocol.name, nullptr, int_client_l.data (), int_port_l.data (), nullptr, nullptr, remaining_mapping_duration_l.data ()));
+		auto verify_port_mapping_error_l (UPNP_GetSpecificPortMappingEntry (upnp.urls.controlURL, upnp.data.first.servicetype, config_port_l.c_str (), protocol.name, protocol.external_address.to_string ().c_str (), int_client_l.data (), int_port_l.data (), nullptr, nullptr, remaining_mapping_duration_l.data ()));
 		auto remaining_from_port_mapping = std::atoi (remaining_mapping_duration_l.data ());
 		auto lease_duration = node.network_params.portmapping.lease_duration.count ();
 		auto lease_duration_divided_by_two = (lease_duration / 2);

--- a/nano/node/portmapping.cpp
+++ b/nano/node/portmapping.cpp
@@ -135,6 +135,20 @@ bool nano::port_mapping::check_lost_or_old_mapping ()
 	auto config_port_l (get_config_port (node_port_l));
 	for (auto & protocol : protocols | boost::adaptors::filtered ([] (auto const & p) { return p.enabled; }))
 	{
+		std::array<char, 64> external_address_l;
+		external_address_l.fill (0);
+		auto external_ip_error_l (UPNP_GetExternalIPAddress (upnp.urls.controlURL, upnp.data.first.servicetype, external_address_l.data ()));
+		if (external_ip_error_l == UPNPCOMMAND_SUCCESS)
+		{
+			boost::system::error_code ec;
+			protocol.external_address = boost::asio::ip::address_v4::from_string (external_address_l.data (), ec);
+			protocol.external_port = static_cast<uint16_t> (std::atoi (config_port_l.data ()));
+		}
+		else
+		{
+			protocol.external_address = boost::asio::ip::address_v4::any ();
+			node.logger.always_log (boost::str (boost::format ("UPNP_GetExternalIPAddress failed %1%: %2%") % external_ip_error_l % strupnperror (external_ip_error_l)));
+		}
 		std::array<char, 64> int_client_l;
 		std::array<char, 6> int_port_l;
 		std::array<char, 16> remaining_mapping_duration_l;
@@ -153,20 +167,6 @@ bool nano::port_mapping::check_lost_or_old_mapping ()
 		{
 			result_l = true;
 			node.logger.always_log (boost::str (boost::format ("UPnP leasing time getting old, remaining time: %1%, lease time: %2%, below the threshold: %3%") % remaining_from_port_mapping % lease_duration % lease_duration_divided_by_two));
-		}
-		std::array<char, 64> external_address_l;
-		external_address_l.fill (0);
-		auto external_ip_error_l (UPNP_GetExternalIPAddress (upnp.urls.controlURL, upnp.data.first.servicetype, external_address_l.data ()));
-		if (external_ip_error_l == UPNPCOMMAND_SUCCESS)
-		{
-			boost::system::error_code ec;
-			protocol.external_address = boost::asio::ip::address_v4::from_string (external_address_l.data (), ec);
-			protocol.external_port = static_cast<uint16_t> (std::atoi (config_port_l.data ()));
-		}
-		else
-		{
-			protocol.external_address = boost::asio::ip::address_v4::any ();
-			node.logger.always_log (boost::str (boost::format ("UPNP_GetExternalIPAddress failed %1%: %2%") % verify_port_mapping_error_l % strupnperror (verify_port_mapping_error_l)));
 		}
 		if (node.config.logging.upnp_details_logging ())
 		{
@@ -220,7 +220,7 @@ void nano::port_mapping::stop ()
 		if (protocol.external_port != 0)
 		{
 			// Be a good citizen for the router and shut down our mapping
-			auto delete_error_l (UPNP_DeletePortMapping (upnp.urls.controlURL, upnp.data.first.servicetype, std::to_string (protocol.external_port).c_str (), protocol.name, address.to_string ().c_str ()));
+			auto delete_error_l (UPNP_DeletePortMapping (upnp.urls.controlURL, upnp.data.first.servicetype, std::to_string (protocol.external_port).c_str (), protocol.name, protocol.external_address.to_string ().c_str ()));
 			if (delete_error_l)
 			{
 				node.logger.always_log (boost::str (boost::format ("UPnP shutdown %1% port mapping response: %2%") % protocol.name % delete_error_l));


### PR DESCRIPTION
To test UPnP: 

- Be sure that external address is not set in config-node.toml.
- Run your node
- Check in your UPnP router configuration that your port mapping is populated and suited.