### PR TITLE
Fix Banano address prefix from 'bano_' to 'ban_'

### DIFF
--- a/nano/core_test/block.cpp
+++ b/nano/core_test/block.cpp
@@ -739,13 +739,13 @@ TEST (block_builder, send)
 	nano::block_builder builder;
 	auto block = builder
 				 .send ()
-				 .destination_address ("bano_1gys8r4crpxhp94n4uho5cshaho81na6454qni5gu9n53gksoyy1wcd4udyb")
+				 .destination_address ("ban_1gys8r4crpxhp94n4uho5cshaho81na6454qni5gu9n53gksoyy1wcd4udyb")
 				 .previous_hex ("F685856D73A488894F7F3A62BC3A88E17E985F9969629FF3FDD4A0D4FD823F24")
 				 .balance_hex ("00F035A9C7D818E7C34148C524FFFFEE")
 				 .build (ec);
 	ASSERT_EQ (block->hash ().to_string (), "4560E7B1F3735D082700CFC2852F5D1F378F7418FD24CEF1AD45AB69316F15CD");
 	ASSERT_FALSE (block->source_field ());
-	ASSERT_EQ (block->destination_field ().value ().to_account (), "bano_1gys8r4crpxhp94n4uho5cshaho81na6454qni5gu9n53gksoyy1wcd4udyb");
+	ASSERT_EQ (block->destination_field ().value ().to_account (), "ban_1gys8r4crpxhp94n4uho5cshaho81na6454qni5gu9n53gksoyy1wcd4udyb");
 	ASSERT_FALSE (block->link_field ());
 }
 

--- a/nano/lib/numbers.cpp
+++ b/nano/lib/numbers.cpp
@@ -77,7 +77,7 @@ void nano::public_key::encode_account (std::ostream & os) const
 	}
 
 	// Write prefix
-	os << "bano_";
+	os << "ban_";
 
 	// Write encoded characters
 	os.write (encoded.data (), encoded.size ());
@@ -107,16 +107,15 @@ bool nano::public_key::decode_node_id (std::string const & source_a)
 
 bool nano::public_key::decode_account (std::string const & source_a)
 {
-	auto error (source_a.size () < 5);
+	auto error (source_a.size () < 4);
 	if (!error)
 	{
 		auto ban_prefix (source_a[0] == 'b' && source_a[1] == 'a' && source_a[2] == 'n' && (source_a[3] == '_' || source_a[3] == '-'));
-		auto nano_prefix (source_a[0] == 'b' && source_a[1] == 'a' && source_a[2] == 'n' && source_a[3] == 'o' && (source_a[4] == '_' || source_a[4] == '-'));
 		auto node_id_prefix = (source_a[0] == 'n' && source_a[1] == 'o' && source_a[2] == 'd' && source_a[3] == 'e' && source_a[4] == '_');
-		error = (ban_prefix && source_a.size () != 64) || (nano_prefix && source_a.size () != 65);
+		error = (ban_prefix && source_a.size () != 64) || (node_id_prefix && source_a.size () != 65);
 		if (!error)
 		{
-			if (ban_prefix || nano_prefix || node_id_prefix)
+			if (ban_prefix || node_id_prefix)
 			{
 				auto i (source_a.begin () + (ban_prefix ? 4 : 5));
 				if (*i == '1' || *i == '3')

--- a/nano/node/nodeconfig.cpp
+++ b/nano/node/nodeconfig.cpp
@@ -63,7 +63,7 @@ nano::node_config::node_config (const std::optional<uint16_t> & peering_port_a, 
 		{
 			preconfigured_peers.emplace_back (default_beta_peer_network);
 			nano::account offline_representative;
-			release_assert (!offline_representative.decode_account ("bano_1defau1t9off1ine9rep99999999999999999999999999999999wgmuzxxy"));
+			release_assert (!offline_representative.decode_account ("ban_1defau1t9off1ine9rep99999999999999999999999999999999wgmuzxxy"));
 			preconfigured_representatives.emplace_back (offline_representative);
 			break;
 		}

--- a/nano/rpc_test/rpc.cpp
+++ b/nano/rpc_test/rpc.cpp
@@ -2852,7 +2852,7 @@ TEST (rpc, accounts_balances)
 
 	// Adds a valid account string that isn't on the ledger for getting an error response.
 	boost::property_tree::ptree entry2;
-	auto const account_not_found = "bano_1os6txqxyuesnxrtshnfb5or1hesc1647wpk9rsr84pmki6eairwha79hk3j";
+	auto const account_not_found = "ban_1os6txqxyuesnxrtshnfb5or1hesc1647wpk9rsr84pmki6eairwha79hk3j";
 	entry2.put ("", account_not_found);
 	accounts_l.push_back (std::make_pair ("", entry2));
 

--- a/nano/secure/common.cpp
+++ b/nano/secure/common.cpp
@@ -43,9 +43,9 @@ char const * dev_genesis_data = R"%%%({
 
 char const * beta_genesis_data = R"%%%({
 	"type": "open",
-	"source": "259A438A8F9F9226130C84D902C237AF3E57C0981C7D709C288046B110D8C8AC",	
-	"representative": "bano_1betag7az9wk6rbis38s1d35hdsycz1bi95xg4g4j148p6afjk7embcurda4",
-	"account": "bano_1betag7az9wk6rbis38s1d35hdsycz1bi95xg4g4j148p6afjk7embcurda4",	
+	"source": "259A438A8F9F9226130C84D902C237AF3E57C0981C7D709C288046B110D8C8AC",
+	"representative": "ban_1betag7az9wk6rbis38s1d35hdsycz1bi95xg4g4j148p6afjk7embcurda4",
+	"account": "ban_1betag7az9wk6rbis38s1d35hdsycz1bi95xg4g4j148p6afjk7embcurda4",
 	"work": "e87a3ce39b43b84c",
 	"signature": "BC588273AC689726D129D3137653FB319B6EE6DB178F97421D11D075B46FD52B6748223C8FF4179399D35CB1A8DF36F759325BD2D3D4504904321FAFB71D7602"
 	})%%%";
@@ -62,8 +62,8 @@ char const * live_genesis_data = R"%%%({
 std::string const test_genesis_data = nano::env::get ("NANO_TEST_GENESIS_BLOCK").value_or (R"%%%({
 	"type": "open",
 	"source": "45C6FF9D1706D61F0821327752671BDA9F9ED2DA40326B01935AB566FB9E08ED",
-	"representative": "bano_1jg8zygjg3pp5w644emqcbmjqpnzmubfni3kfe1s8pooeuxsw49fdq1mco9j",
-	"account": "bano_1jg8zygjg3pp5w644emqcbmjqpnzmubfni3kfe1s8pooeuxsw49fdq1mco9j",
+	"representative": "ban_1jg8zygjg3pp5w644emqcbmjqpnzmubfni3kfe1s8pooeuxsw49fdq1mco9j",
+	"account": "ban_1jg8zygjg3pp5w644emqcbmjqpnzmubfni3kfe1s8pooeuxsw49fdq1mco9j",
 	"work": "bc1ef279c1a34eb1",
 	"signature": "15049467CAEE3EC768639E8E35792399B6078DA763DA4EBA8ECAD33B0EDC4AF2E7403893A5A602EB89B978DABEF1D6606BB00F3C0EE11449232B143B6E07170E"
     })%%%");
@@ -198,7 +198,7 @@ nano::ledger_constants::ledger_constants (nano::work_thresholds & work, nano::ne
 		case networks::banano_live_network:
 		{
 			genesis = nano_live_genesis;
-			epoch_v2_signer = nano::account::from_account ("bano_3qb6o6i1tkzr6jwr5s7eehfxwg9x6eemitdinbpi7u8bjjwsgqfj4wzser3x");
+			epoch_v2_signer = nano::account::from_account ("ban_3qb6o6i1tkzr6jwr5s7eehfxwg9x6eemitdinbpi7u8bjjwsgqfj4wzser3x");
 		}
 		break;
 		case networks::banano_beta_network:


### PR DESCRIPTION
Changed the address encoding to use 'ban_' prefix instead of 'bano_' for Banano addresses. This brings the address format in line with the expected standard where ban_ is the correct 4-character prefix.

Changes:
- Updated address encoding in numbers.cpp to output 'ban_' prefix
- Modified decoding logic to only accept 'ban_' prefix (removed 'bano_' support)
- Updated all test addresses from 'bano_' to 'ban_'
- Fixed genesis block addresses in common.cpp
- Corrected configuration addresses in nodeconfig.cpp