### PR TITLE
Add CMake validation and docs for ACTIVE_NETWORK option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -159,6 +159,23 @@ set(ACTIVE_NETWORK
 set_property(
   CACHE ACTIVE_NETWORK PROPERTY STRINGS banano_dev_network banano_beta_network
                                 banano_live_network banano_test_network)
+
+# Validate ACTIVE_NETWORK value
+set(VALID_NETWORKS "banano_dev_network;banano_beta_network;banano_live_network;banano_test_network")
+if(NOT ACTIVE_NETWORK IN_LIST VALID_NETWORKS)
+  message(FATAL_ERROR
+    "Invalid ACTIVE_NETWORK value: '${ACTIVE_NETWORK}'\n"
+    "Valid options are:\n"
+    "  - banano_dev_network   (Development network with low work parameters)\n"
+    "  - banano_beta_network  (Beta network for testing)\n"
+    "  - banano_live_network  (Live production network - default)\n"
+    "  - banano_test_network  (Test network)\n"
+    "\n"
+    "Example usage:\n"
+    "  cmake -DACTIVE_NETWORK=banano_test_network ."
+  )
+endif()
+
 set(CPACK_PACKAGE_NAME
     "nano-node"
     CACHE STRING "" FORCE)

--- a/README.md
+++ b/README.md
@@ -37,6 +37,44 @@ For more information, see [Banano.cc](https://banano.cc).
 ### Build instructions
 - [Building Banano from source](https://github.com/BananoCoin/banano/wiki/Building-a-Bananode-from-sources)
 
+### Building with CMake
+
+When building Banano with CMake, you can configure which network to build for using the `ACTIVE_NETWORK` option:
+
+```bash
+cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+      -DACTIVE_NETWORK=banano_live_network \
+      -DNANO_TEST=ON .
+```
+
+**Valid `ACTIVE_NETWORK` values:**
+
+| Network | Description |
+|---------|-------------|
+| `banano_dev_network` | Development network with low work parameters and publicly known genesis key |
+| `banano_beta_network` | Beta network with normal work parameters and secret beta genesis key |
+| `banano_live_network` | **Default.** Live production network with normal work parameters |
+| `banano_test_network` | Test network with normal work parameters and secret test genesis key |
+
+If you don't specify `ACTIVE_NETWORK`, it defaults to `banano_live_network`.
+
+**Common build configurations:**
+
+```bash
+# Production build (default)
+cmake -DCMAKE_BUILD_TYPE=Release .
+
+# Development build with tests
+cmake -DCMAKE_BUILD_TYPE=Debug \
+      -DACTIVE_NETWORK=banano_dev_network \
+      -DNANO_TEST=ON .
+
+# Test network build
+cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+      -DACTIVE_NETWORK=banano_test_network \
+      -DNANO_TEST=ON .
+```
+
 ### Running a Docker node
 - [Running a Docker node](https://github.com/BananoCoin/banano/wiki/Running-a-Docker-Bananode)
 


### PR DESCRIPTION
This change addresses build failures when invalid ACTIVE_NETWORK values are used. Previously, using an invalid value like "banano_live" (without the "_network" suffix) would result in a cryptic C++ enum error during compilation.

Changes:
1. Added CMake validation that checks ACTIVE_NETWORK against the list of valid values and provides a clear, helpful error message with:
   - The invalid value that was provided
   - A complete list of valid options with descriptions
   - Example usage showing the correct format

2. Added comprehensive documentation in README.md including:
   - Valid ACTIVE_NETWORK values in a table format
   - Descriptions of each network type
   - Common build configuration examples
   - Clear indication that banano_live_network is the default

The validation now catches configuration errors early in the CMake phase rather than during compilation, significantly improving the developer experience.