### PR TITLE
Fix online weight minimum

### DIFF
--- a/nano/node/nodeconfig.hpp
+++ b/nano/node/nodeconfig.hpp
@@ -86,7 +86,7 @@ public:
 	nano::amount vote_minimum{ nano::MBAN_ratio }; // 1000 nano
 	nano::amount rep_crawler_weight_minimum{ "FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF" };
 	std::chrono::milliseconds vote_generator_delay{ std::chrono::milliseconds (100) };
-	nano::amount online_weight_minimum{ 60000 * nano::MBAN_ratio }; // 60 million nano
+	nano::amount online_weight_minimum{ 900 * nano::MBAN_ratio }; // 900 million nano
 	/*
 	 * The minimum vote weight that a representative must have for its vote to be counted.
 	 * All representatives above this weight will be kept in memory!


### PR DESCRIPTION
Restore to 900 million, not 6 billion.

This config mistake also present in v26 branches